### PR TITLE
Better global flashlight

### DIFF
--- a/items/item_types/flashlight/flashlight.gd
+++ b/items/item_types/flashlight/flashlight.gd
@@ -16,19 +16,6 @@ func _ready() -> void:
 	
 	battery_component.battery_ran_out.connect(_on_battery_ran_out)
 	
-	self.selected.connect(_on_select.call_deferred)
-	self.unselected.connect(_on_unselect.call_deferred)
-	
-	
-func _on_unselect() -> void:
-	self.model.visible = true
-	self.flashlight_model.visible = false
-	self.flashlight_spotlight.visible = toggleable_component.active
-	
-func _on_select() -> void:
-	self.flashlight_model.visible = true
-	self.flashlight_spotlight.visible = toggleable_component.active
-	
 	
 func _on_toggle_on() -> void:
 	flashlight_spotlight.visible = true

--- a/items/item_types/flashlight/flashlight.tscn
+++ b/items/item_types/flashlight/flashlight.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=3 uid="uid://d0pwkaakif8sj"]
+[gd_scene load_steps=10 format=3 uid="uid://d0pwkaakif8sj"]
 
 [ext_resource type="Script" uid="uid://cv03ob7bjx58g" path="res://items/components/toggleable_component.gd" id="1_irxr7"]
 [ext_resource type="Script" uid="uid://jhx0it63g85o" path="res://items/item_types/flashlight/flashlight.gd" id="1_pkemv"]
@@ -6,6 +6,7 @@
 [ext_resource type="Script" uid="uid://dbw8ccs3wetgd" path="res://items/components/battery_powered_component.gd" id="2_eafmh"]
 [ext_resource type="Script" uid="uid://dweiut1euqc8c" path="res://script/node_3d/soft_follow.gd" id="4_3jd6t"]
 [ext_resource type="PackedScene" uid="uid://dymnmir2nh0m0" path="res://items/item_types/flashlight/model/flashlight_model.tscn" id="5_pkemv"]
+[ext_resource type="Script" uid="uid://bkgw7f3r5fh1k" path="res://script/node_3d/copy_position.gd" id="7_m4vst"]
 
 [sub_resource type="Gradient" id="Gradient_cgiyt"]
 offsets = PackedFloat32Array(0, 0.25, 0.5, 0.75, 1)
@@ -50,12 +51,18 @@ transform = Transform3D(2.33714, 0, 0, 0, 2.33714, 0, 0, 0, 2.33714, 0.282044, -
 unique_name_in_owner = true
 transform = Transform3D(-0.382248, 0, 0.92406, -0.0234313, 0.999678, -0.00969263, -0.923763, -0.0253569, -0.382125, 0, -0.0128502, 0.0160573)
 
-[node name="FlashlightSpotLight" type="SpotLight3D" parent="Model/Flashlight"]
+[node name="SpotlightPosition" type="Node3D" parent="Model/Flashlight/FlashlightModel"]
+transform = Transform3D(-0.382248, -0.0234313, -0.923763, 6.55535e-09, 0.999678, -0.0253569, 0.92406, -0.00969262, -0.382125, 0.0764372, 0.0153043, 0.0308273)
+
+[node name="Node" type="Node" parent="Model/Flashlight"]
+
+[node name="FlashlightSpotLight" type="SpotLight3D" parent="Model/Flashlight/Node" node_paths=PackedStringArray("position_parent")]
 unique_name_in_owner = true
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.000731692, 0.000359356, -0.0667205)
-visible = false
+transform = Transform3D(1, 1.86264e-09, 2.98023e-08, -1.86265e-09, 1, 8.3819e-09, -2.98023e-08, -8.3819e-09, 1, 0.280334, -0.263433, -0.426302)
 light_projector = SubResource("GradientTexture2D_pkemv")
 shadow_enabled = true
 spot_range = 7.5
 spot_attenuation = 2.0
 spot_angle = 40.0
+script = ExtResource("7_m4vst")
+position_parent = NodePath("../../FlashlightModel/SpotlightPosition")

--- a/script/node_3d/copy_position.gd
+++ b/script/node_3d/copy_position.gd
@@ -1,0 +1,7 @@
+extends Node3D
+
+@export var position_parent: Node3D
+
+func _process(_delta: float) -> void:
+	self.global_basis = position_parent.global_basis
+	self.global_position = position_parent.global_position

--- a/script/node_3d/copy_position.gd.uid
+++ b/script/node_3d/copy_position.gd.uid
@@ -1,0 +1,1 @@
+uid://bkgw7f3r5fh1k


### PR DESCRIPTION
- Added a copy_position script
- Used a copy_position node to attach the flashlight spotlight to the flashlight model without it being a child of the model. This allows for the spotlight to stay visible even if the flashlight model is invisible without using dirty signal timing hacks