### PR TITLE
Save load settings

### DIFF
--- a/game/game.gd
+++ b/game/game.gd
@@ -64,17 +64,29 @@ func reset() -> void:
 	_internal_time = START_TIME
 	
 	
-func print(...args: Array) -> void:
-	player.dev_console.print_console.callv(args)
+func print_message(...args: Array) -> void:
+	if player != null and player.dev_console != null:
+		player.dev_console.print_console.callv(args)
+	else:
+		print.callv(args)
 	
 	
 func print_info(...args: Array) -> void:
-	player.dev_console.print_info_console.callv(args)
+	if player != null and player.dev_console != null:
+		player.dev_console.print_info_console.callv(args)
+	else:
+		print.callv(args)
 	
 	
 func print_warning(...args: Array) -> void:
-	player.dev_console.print_warning_console.callv(args)
+	if player != null and player.dev_console != null:
+		player.dev_console.print_warning_console.callv(args)
+	else:
+		push_warning.callv(args)
 	
 	
 func print_error(...args: Array) -> void:
-	player.dev_console.print_error_console.callv(args)
+	if player != null and player.dev_console != null:
+		player.dev_console.print_error_console.callv(args)
+	else:
+		push_error.callv(args)

--- a/game/settings.gd
+++ b/game/settings.gd
@@ -4,6 +4,10 @@ extends Node
 ## editing the variable directly won't correctly emit the setting_changed signal.
 ## Use [code]set_setting[/code] instead
 
+const SAVE_PATH: String = "user://settings.ini"
+
+const SETTINGS_FILE_VERSION: int = 1
+
 const MAIN_BUS_NAME: StringName = &"Master"
 const MUSIC_BUS_NAME: StringName = &"Music"
 const SOUNDS_BUS_NAME: StringName = &"Sounds"
@@ -29,17 +33,55 @@ var ambiance_sounds_volume: float = 1
 
 func _ready() -> void:
 	self.setting_changed.connect(_on_setting_changed)
+	load_settings()
+	
+	
+func _notification(notif: int) -> void:
+	if notif == NOTIFICATION_WM_CLOSE_REQUEST \
+	or notif == NOTIFICATION_WM_GO_BACK_REQUEST \
+	or notif == NOTIFICATION_APPLICATION_PAUSED:
+		save_settings()
 
 
 ## Loads the settings from the save file.
 ## This will emit the [code]setting_changed[/code] signal for each loaded setting.
-func load() -> void:
-	pass
+func load_settings() -> void:
+	var file := ConfigFile.new()
+	var first_load: bool = false
+	var error: int = file.load(SAVE_PATH)
+	if error:
+		if error == Error.ERR_FILE_NOT_FOUND:
+			Game.print_info("Settings file not found, using default settings")
+			first_load = true
+		else:
+			Game.print_error("An error occured while loading settings: ", error_string(error))
+			return
+			
+	var save_file_version: int
+	if first_load:
+		save_file_version = SETTINGS_FILE_VERSION
+	else:
+		save_file_version = file.get_value("Meta", "SETTINGS_FILE_VERSION", 0)
+	if not save_file_version:
+		Game.print_error("Could not read settings file version, errors may occur")
+		
+	for setting_type_name in Type.keys():
+		set_setting(file.get_value("Settings", setting_type_name, get_setting(Type[setting_type_name])), Type[setting_type_name])
 	
 	
 ## Saves the settings to the save file
-func save() -> void:
-	pass
+func save_settings() -> void:
+	var file := ConfigFile.new()
+	
+	file.set_value("Meta", "SETTINGS_FILE_VERSION", SETTINGS_FILE_VERSION)
+	
+	for setting_type_name in Type.keys():
+		file.set_value("Settings", setting_type_name, get_setting(Type[setting_type_name]))
+	
+	var error: int = file.save(SAVE_PATH)
+	if error:
+		Game.print_error("An error occured while saving settings: ", error_string(error))
+		
 	
 	
 ## Returns the setting of the given type

--- a/menus/settings_menu/settings_menu.gd
+++ b/menus/settings_menu/settings_menu.gd
@@ -13,6 +13,11 @@ func open() -> void:
 	super.open()
 	
 	
+func close() -> void:
+	super.close()
+	Settings.save_settings()
+	
+	
 func on_focus() -> void:
 	super.on_focus()
 	tab_bar.grab_focus()

--- a/menus/settings_menu/settings_menu.tscn
+++ b/menus/settings_menu/settings_menu.tscn
@@ -164,23 +164,21 @@ theme_override_constants/separation = 8
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 4
-min_value = 0.5
+min_value = 0.1
 max_value = 20.0
 step = 0.1
 value = 6.0
 allow_greater = true
-allow_lesser = true
 script = ExtResource("3_r0vi3")
 
 [node name="SensibilitySpinBox" type="SpinBox" parent="MarginContainer/VBoxContainer/Control/MarginContainer/ControlsTab/GridContainer/SensibilitySetting"]
 layout_mode = 2
 size_flags_horizontal = 8
-min_value = 0.5
+min_value = 0.1
 max_value = 20.0
 step = 0.1
 value = 6.0
 allow_greater = true
-allow_lesser = true
 custom_arrow_step = 0.1
 select_all_on_focus = true
 script = ExtResource("3_r0vi3")

--- a/player/dev_console/debug_commands.gd
+++ b/player/dev_console/debug_commands.gd
@@ -52,7 +52,7 @@ func give(item: String) -> void:
 	match item:
 		"battery":
 			Game.player.inventory.add_consumable(Consumable.Type.BATTERY)
-			Game.print("Gave one battery")
+			Game.print_message("Gave one battery")
 		_:
 			Game.print_error("Unknown item: ", item)
 	


### PR DESCRIPTION
Handle settings file load and save  
The settings file will be loaded as soon as the game starts, and will be saved when exiting the settings menu and when the game closes  

Made the Game print functions safe to call when the game did not start yet  
Rename the Game `print` function to `print_message` to prevent name collision with the global scope `print` function  

The sensibility now can't be negative  
